### PR TITLE
Add `git submodule update --init` to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+git submodule update --init
+
 bundle install
 
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
Follow up of #4.

This PR adds `git submodule update --init` to bin/setup

## Before

```console
% bin/setup

bundle install
+ bundle install
Fetching gem metadata from https://rubygems.org/...........
Could not find gem 'ruby-signature' in source at
`vendor/ruby-signature`.
The source does not contain any versions of 'ruby-signature'
```

## After

```console
% bin/setup

git submodule update --init
+ git submodule update --init
Submodule
'vendor/ruby-signature' (https://github.com/ruby/ruby-signature.git)
registered for path 'vendor/ruby-signature'
Submodule 'vendor/steep' (https://github.com/soutaro/steep.git)
registered for path 'vendor/steep'
Cloning into '/private/tmp/foo/rubocop-typed/vendor/ruby-signature'...
Cloning into '/private/tmp/foo/rubocop-typed/vendor/steep'...
Submodule path 'vendor/ruby-signature': checked out
'b0bb4d56835ef8f530ff5a10d9d4443f81ee8801'
Submodule path 'vendor/steep': checked out
'a286310c10471e0ca4247a41471bcc0d7722dff0'

bundle install
+ bundle install
Fetching gem metadata from https://rubygems.org/..........
Using rake 12.3.3

(snip)

Using steep 0.11.1 from source at `vendor/steep`
Using rubocop-typed 0.1.0 from source at `.`
Using ruby-signature 0.1.0 from source at `vendor/ruby-signature`
Bundle complete! 5 Gemfile dependencies, 36 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

# Do any other automated setup that you need to do here
```